### PR TITLE
fix order of tags in `<head>`

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@ https://github.com/KK4OXJ/KK4OXJ.github.io
 -->
 
 <head>
-  <link rel="stylesheet" href="style.css">
-  
   <meta charset="utf-8">
+  <title>Zeke Y - Web designer/developer</title>
+  
   <meta name="robots" content="index, follow, archive, cache, imageindex">
   <meta name="author" content="Zeke Y">
   <meta http-equiv="cache-control" content="public" max-age="604800">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  
-  <title>Zeke Y - Web designer/developer</title>
+
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <!-- Header -->


### PR DESCRIPTION
It's important your charset declaration comes before any other things (such as the `<title>` ) in the `<head>` of your page. [Also it's important it gets loaded within the first `1024` bytes of your page.](https://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#charset)

Please refer to https://github.com/h5bp/html5-boilerplate/blob/master/dist/doc/html.md#the-order-of-the-title-and-meta-tags
